### PR TITLE
Execute commands from BASE direcctory

### DIFF
--- a/addons/Spock/SpockListener.php
+++ b/addons/Spock/SpockListener.php
@@ -39,7 +39,7 @@ class SpockListener extends Listener
 
         $this->data = $data;
 
-        $process = new Process($this->commands());
+        $process = new Process($this->commands(), BASE);
 
         $process->run();
     }


### PR DESCRIPTION
This is useful when Statamic is installed above the web root, otherwise it assumes executing commands from the directory index.php was called from.