### PR TITLE
Use quotes for commit message, not apostrophes

### DIFF
--- a/addons/Spock/Git.php
+++ b/addons/Spock/Git.php
@@ -36,7 +36,7 @@ class Git
             $commands[] = "git add {$path}";
         }
 
-        $commands[] = vsprintf("git commit -m '%s%s'", [
+        $commands[] = vsprintf('git commit -m "%s%s"', [
             $this->label(),
             $this->user ? ' by ' . $this->user->username() : ''
         ]);


### PR DESCRIPTION
Using apostrophes instead of quotes in some environment seems to cause git to attempt to evaluate the commit message and throw the following errors:

```
[2018-08-02 17:05:04] staging.ERROR: Spock command exited unsuccessfully:
Command: git commit -m 'Page saved by user'
Output: No output
Error: 
error: pathspec 'saved' did not match any file(s) known to git.
error: pathspec 'by' did not match any file(s) known to git.
error: pathspec 'user'' did not match any file(s) known to git.
```

The change in this commit should resolve the issue.