### PR TITLE
Add author to commits

### DIFF
--- a/addons/Spock/Git.php
+++ b/addons/Spock/Git.php
@@ -59,20 +59,35 @@ class Git
         $parts = ['git'];
 
         if ($username = array_get($this->config, 'git_username')) {
-            $parts[] = sprintf('-c "user.name=%s"', $username);
+            $parts[] = '-c';
+            $parts[] = escapeshellarg("user.name=" . $username);
         }
 
         if ($email = array_get($this->config, 'git_email')) {
-            $parts[] = sprintf('-c "user.email=%s"', $email);
+            $parts[] = '-c';
+            $parts[] = escapeshellarg("user.email=" . $email);
         }
 
-        $message = 'commit -m "' . $this->label();
-        $message .= $this->user ? ' by ' . $this->user->username() : '';
-        $message .= '"';
-        $parts[] = $message;
-
+        $parts[] = 'commit';
+        if ($this->user) {
+            $parts[] = escapeshellarg($this->author());
+        }
+        $parts[] = '-m';
+        $parts[] = escapeshellarg(sprintf("%s%s", $this->label(), $this->user ? ' by ' . $this->user->username() : ''));
         return join(' ', $parts);
     }
+
+
+
+    /**
+     * Create a Git author parameter from the user's name and email address,
+     * i.e, "--author=A U Thor <author@example.com>"
+     */
+    protected function author() {
+        $user = $this->user->toArray();
+        return sprintf("--author=%s <%s>", $user['name'], $user['email']);
+    }
+
 
     /**
      * Get the label of the class, which is the action name.

--- a/addons/Spock/Git.php
+++ b/addons/Spock/Git.php
@@ -32,9 +32,7 @@ class Git
     {
         $commands = array_get($this->config, 'commands_before', []);
 
-        foreach ($this->event->affectedPaths() as $path) {
-            $commands[] = "git add {$path}";
-        }
+        $commands[] = "git add --all";
 
         $commands[] = $this->commitCommand();
 


### PR DESCRIPTION
Git distinguishes between author and committer. The configured
committer details in `site/settings/addons/spock.yaml` are fine,
but the Statamic user who is logged in should be credited with
the authorship. The log show both. For example with `spock.yaml`
like the example:

``` yaml
git_username: Spock
git_email: spock@domain.com
```

And a user (username "bob", first name "Bob", last name "Author", email "bob@example.com").
The log will look something like:

```
git log --pretty=full
Author: Bob Author <bob@example.com>
Commit: Spock <spock@domain.com>

    Entry deleted by bob
```

This is somewhat opposite to the desires expressed in issue #25, having the commit message itself include something like "[spock]" to distinguish it from typical developer commits. However there is no conflict between this and that. We can do both.

My apologies for breaking all the tests. I'm not really a PHP developer, and my feeble attempt at running the test is greeted with a definite error message:

```
php addons/Spock/tests/GitTest.php 

Fatal error: Class 'PHPUnit_Framework_TestCase' not found in /Users/knut/opensource/spock/addons/Spock/tests/GitTest.php on line 10
```
I may need a pointer to how to run the tests effectively.

Also part of the pull request is a change from looking at "affected paths", and instead commit all outstanding changes. There seems to be an issue with some changes (draft blog entries) not being accurately reflected in "affected paths". Maybe this aspect should have ben a different pull request altogether.

Finally I'm using the standard `escapeshellarg` to escape any potential malicious input to the shell command. I notice commit b4a89a4c7cff3ef5ff6da35471d6507182f65076 is opposite in some ways, but I suspect that is just a workaround for a different culprit.
